### PR TITLE
add support to golang test

### DIFF
--- a/app.go
+++ b/app.go
@@ -121,6 +121,9 @@ func (a *App) Run(arguments []string) (err error) {
 		}
 	}
 
+	a.appendFlag(TestShortFlag)
+	a.appendFlag(TestVerboseFlag)
+
 	//append version/help flags
 	if a.EnableBashCompletion {
 		a.appendFlag(BashCompletionFlag)

--- a/flag.go
+++ b/flag.go
@@ -29,6 +29,16 @@ var HelpFlag = BoolFlag{
 	Usage: "show help",
 }
 
+var TestShortFlag = BoolFlag{
+	Name:  "test.short",
+	Usage: "support golang test with short report",
+}
+
+var TestVerboseFlag = BoolFlag{
+	Name:  "test.v",
+	Usage: "support golang test with verbose report",
+}
+
 // Flag is a common interface related to parsing flags in cli.
 // For more advanced flag parsing techniques, it is recommended that
 // this interface be implemented.


### PR DESCRIPTION
 Hi, I am using go-micro in [my project](https://github.com/zouqilin/micro_service_deployed_by_k8s
), but when I run test in the `micro_service_deployed_by_k8s/srv/user`, no test ran, it just outputs as follows:
![image](https://user-images.githubusercontent.com/3761283/33358305-d7450108-d502-11e7-88d3-4d258eceff68.png)
after researched, i found something in the golang test.
1. firstly, golang test will generate an executable file in `/tmp/go-build***/micro`
1. then, golang test execute `/tmp/go-build***/micro` with argument `-test.v=true` or `-test.short=true`
In the [micro/cli](https://github.com/micro/cli), we don't handle test flag. so when i ran `go test`. it reported micro usage.
I fixed it by [the commit](https://github.com/zouqilin/cli/commit/bbee497b6819880b3b438d3ba4e6719a2ff9cd40)
I add two flags `TestShortFlag` and `TestVerboseFlag`, both are `BoolFlag`. and append them to `app.Flags` when call `app.Run()`
then, I ran `go test`. It works.
![image](https://user-images.githubusercontent.com/3761283/33358602-8cb6601c-d504-11e7-910d-12b00de88881.png)

pls let me know if any problems.
thanks for your reading.
