### PR TITLE
Assign the newVal to the old pointer

### DIFF
--- a/flag.go
+++ b/flag.go
@@ -157,7 +157,13 @@ func (f StringSliceFlag) Apply(set *flag.FlagSet) {
 					s = strings.TrimSpace(s)
 					newVal.Set(s)
 				}
-				f.Value = newVal
+
+				if f.Value != nil {
+					*f.Value = *newVal
+				} else {
+					f.Value = newVal
+				}
+
 				break
 			}
 		}


### PR DESCRIPTION
Resolves https://github.com/micro/cli/issues/4

This allows the environment variable to overwrite the contents of f.Value without losing access to the new values.

Alternatively, could check if it's not nil and append like it does for passed flags.