### PR TITLE
Removes unused variables caught by 'go vet' preventing app_test.go from compiling in Go 1.12.

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -305,7 +305,6 @@ func TestApp_Float64Flag(t *testing.T) {
 }
 
 func TestApp_ParseSliceFlags(t *testing.T) {
-	var parsedOption, firstArg string
 	var parsedIntSlice []int
 	var parsedStringSlice []string
 
@@ -319,8 +318,6 @@ func TestApp_ParseSliceFlags(t *testing.T) {
 		Action: func(c *Context) {
 			parsedIntSlice = c.IntSlice("p")
 			parsedStringSlice = c.StringSlice("ip")
-			parsedOption = c.String("option")
-			firstArg = c.Args().First()
 		},
 	}
 	app.Commands = []Command{command}


### PR DESCRIPTION
Fixes the following error when trying to compile app_test.go on Go 1.12:

    # github.com/micro/cli
    vet: ..\..\micro\cli\app_test.go:308:6: parsedOption declared but not used

Removes two unused variables in the TestApp_ParseSliceFlags() test.

Mirrors this change to upstream: urfave/cli@c3cc74dac756e33c2919ab998481809e8720e068